### PR TITLE
feat(toolbar): Indicador 'Just Now' + botón Refresh con cooldown progresivo

### DIFF
--- a/src/components/ActionToolbar.js
+++ b/src/components/ActionToolbar.js
@@ -2,9 +2,27 @@ import Button from "./Button";
 import { getSource, DEFAULT_SOURCE } from "../utils/sources";
 import { openAddExchangeModal } from "./AddExchangeModal";
 import { openAddAssetModal } from "./AddAssetModal";
+import { formatRelativeTime } from "../utils/formatters";
 import sprite from "../assets/sprite.svg";
 
 export let currentFilter = DEFAULT_SOURCE;
+
+// ─── Cooldown Config ─────────────────────────────────────────────────────────
+/** Niveles de cooldown en segundos (se escala con cada refresh manual). */
+const COOLDOWNS = [60, 120, 300, 600];
+
+/** @type {number} Nivel de cooldown actual (0–3). */
+let _cooldownLevel = 0;
+/** @type {number | null} Unix timestamp (segundos) del fin del cooldown activo. */
+let _cooldownEndTime = null;
+/** @type {number} Unix timestamp (segundos) del último fetch exitoso. */
+let _lastFetchTimestamp = 0;
+/** @type {ReturnType<typeof setInterval> | null} ID del intervalo de tick. */
+let _tickInterval = null;
+/** @type {boolean} Guard para evitar peticiones concurrentes. */
+let _isFetching = false;
+
+// ─── Component ───────────────────────────────────────────────────────────────
 
 const ActionToolbar = () => {
   const sources = getSource();
@@ -74,13 +92,162 @@ const ActionToolbar = () => {
           </div>
         </div>
 
-        ${Button("add-funds", "plus", "Add Funds", "btn-hover-glow bg-primary text-slate-900 font-bold hover:brightness-110 px-3 py-1")}
+        <!-- Right group: indicator + refresh + add funds -->
+        <div class="flex items-center gap-3 shrink-0">
+          <!-- Indicador "last update" — visible solo en sm+ -->
+          <span
+            id="last-update-indicator"
+            aria-live="polite"
+            aria-atomic="true"
+            class="text-xs text-slate-400 hidden sm:inline"
+          ></span>
+
+          <!-- Botón de refresco con cooldown -->
+          <button
+            id="refresh-prices-btn"
+            aria-label="Refresh prices"
+            class="btn-press flex items-center justify-center gap-1.5 px-3 py-1.5 bg-slate-800 border border-slate-700 hover:border-slate-500 rounded-lg text-slate-300 text-sm font-medium transition-all"
+          >
+            <svg id="refresh-btn-icon" class="w-4 h-4 text-slate-400 transition-transform" aria-hidden="true">
+              <use href="${sprite}#refresh" />
+            </svg>
+            <span class="btn-label">Refresh</span>
+            <span class="cooldown-text hidden text-slate-400 tabular-nums"></span>
+          </button>
+
+          ${Button("add-funds", "plus", "Add Funds", "btn-hover-glow bg-primary text-slate-900 font-bold hover:brightness-110 px-3 py-1")}
+        </div>
       </section>
     </div>
   `;
 
   return view;
-}
+};
+
+// ─── Button State Machine ─────────────────────────────────────────────────────
+
+/**
+ * Actualiza el estado visual del botón de refresco.
+ * @param {'idle' | 'loading' | 'cooldown' | 'error'} state
+ * @param {number} [remaining] - Segundos restantes (solo en estado 'cooldown').
+ */
+const _setButtonState = (state, remaining = 0) => {
+  const btn = document.getElementById('refresh-prices-btn');
+  if (!btn) return;
+
+  const icon = btn.querySelector('#refresh-btn-icon');
+  const label = btn.querySelector('.btn-label');
+  const cooldownText = btn.querySelector('.cooldown-text');
+
+  // Reset clases del botón
+  btn.classList.remove(
+    'border-red-500/50', 'hover:border-red-500/70', 'text-red-400',
+    'opacity-60', 'cursor-not-allowed'
+  );
+
+  switch (state) {
+    case 'idle':
+      btn.disabled = false;
+      btn.setAttribute('aria-label', 'Refresh prices');
+      icon?.classList.remove('animate-spin', 'hidden');
+      label?.classList.remove('hidden');
+      label && (label.textContent = 'Refresh');
+      cooldownText?.classList.add('hidden');
+      break;
+
+    case 'loading':
+      btn.disabled = true;
+      btn.setAttribute('aria-label', 'Refreshing prices, please wait');
+      btn.classList.add('opacity-60', 'cursor-not-allowed');
+      icon?.classList.add('animate-spin');
+      icon?.classList.remove('hidden');
+      label?.classList.remove('hidden');
+      label && (label.textContent = 'Updating...');
+      cooldownText?.classList.add('hidden');
+      break;
+
+    case 'cooldown': {
+      btn.disabled = true;
+      btn.setAttribute('aria-label', `Refresh available in ${remaining} seconds`);
+      btn.classList.add('opacity-60', 'cursor-not-allowed');
+      icon?.classList.remove('animate-spin');
+      icon?.classList.add('hidden');
+      label?.classList.add('hidden');
+      cooldownText?.classList.remove('hidden');
+      cooldownText && (cooldownText.textContent = `Wait ${remaining}s`);
+      break;
+    }
+
+    case 'error':
+      btn.disabled = false;
+      btn.setAttribute('aria-label', 'Refresh failed. Click to retry');
+      btn.classList.add('border-red-500/50', 'hover:border-red-500/70', 'text-red-400');
+      icon?.classList.remove('animate-spin', 'hidden');
+      label?.classList.remove('hidden');
+      label && (label.textContent = 'Failed');
+      cooldownText?.classList.add('hidden');
+      break;
+  }
+};
+
+// ─── Tick Interval ────────────────────────────────────────────────────────────
+
+/** Actualiza el indicador de última actualización y controla fin de cooldown. */
+const _updateTimestampDisplay = () => {
+  const indicator = document.getElementById('last-update-indicator');
+  const now = Math.floor(Date.now() / 1000);
+
+  // 1. Actualizar indicador de última carga
+  if (indicator && _lastFetchTimestamp > 0) {
+    const elapsed = now - _lastFetchTimestamp;
+    indicator.textContent = `Updated ${formatRelativeTime(elapsed)}`;
+  }
+
+  // 2. Controlar finalización del Cooldown
+  if (!_isFetching && _cooldownEndTime !== null) {
+    const remaining = _cooldownEndTime - now;
+    if (remaining > 0) {
+      _setButtonState('cooldown', remaining);
+    } else {
+      _cooldownEndTime = null;
+      _setButtonState('idle');
+    }
+  }
+
+  // 3. Decremento de nivel de Cooldown por inactividad prolongada
+  if (_cooldownLevel > 0 && _lastFetchTimestamp > 0) {
+    const inactiveFor = now - _lastFetchTimestamp;
+    const currentCooldown = COOLDOWNS[_cooldownLevel] ?? 600;
+    if (inactiveFor > currentCooldown * 2) {
+      _cooldownLevel = 0;
+    }
+  }
+};
+
+const _startTickInterval = () => {
+  if (_tickInterval !== null) clearInterval(_tickInterval);
+  _tickInterval = setInterval(_updateTimestampDisplay, 1000);
+};
+
+const _stopTickInterval = () => {
+  if (_tickInterval !== null) {
+    clearInterval(_tickInterval);
+    _tickInterval = null;
+  }
+};
+
+// ─── Event Handlers (module-level refs for cleanup) ───────────────────────────
+
+/** @type {((e: Event) => void) | null} */
+let _scrollFadeHandler = null;
+/** @type {((e: Event) => void) | null} */
+let _clickDropdownHandler = null;
+/** @type {((e: Event) => void) | null} */
+let _pricesUpdatedHandler = null;
+/** @type {((e: Event) => void) | null} */
+let _pricesFailedHandler = null;
+
+// ─── Init ─────────────────────────────────────────────────────────────────────
 
 export const initActionToolbar = () => {
   cleanupActionToolbar();
@@ -90,7 +257,7 @@ export const initActionToolbar = () => {
   if (addWalletBtn) {
     addWalletBtn.addEventListener("click", () => {
       openAddExchangeModal({
-        onSave: (exchange) => {
+        onSave: () => {
           const wrapper = document.getElementById("action-toolbar-wrapper");
           if (wrapper) {
             wrapper.outerHTML = ActionToolbar();
@@ -121,9 +288,8 @@ export const initActionToolbar = () => {
       dropdownChevron?.classList.toggle("rotate-180", !isOpen);
     });
 
-    // Cerrar al hacer click fuera
     _clickDropdownHandler = (e) => {
-      if (dropdownBtn && dropdownMenu && !dropdownBtn.contains(e.target) && !dropdownMenu.contains(e.target)) {
+      if (dropdownBtn && dropdownMenu && !dropdownBtn.contains(/** @type {Node} */(e.target)) && !dropdownMenu.contains(/** @type {Node} */(e.target))) {
         dropdownMenu.classList.add("hidden");
         dropdownBtn.setAttribute("aria-expanded", "false");
         dropdownChevron?.classList.remove("rotate-180");
@@ -135,9 +301,9 @@ export const initActionToolbar = () => {
   // Filter Buttons (desktop + dropdown)
   document.querySelectorAll('.action-filter-btn').forEach(btn => {
     btn.addEventListener('click', (e) => {
-      const filter = e.currentTarget.dataset.filter;
+      const filter = /** @type {HTMLButtonElement} */(e.currentTarget).dataset.filter;
       if (currentFilter !== filter) {
-        currentFilter = filter;
+        currentFilter = filter ?? currentFilter;
         window.dispatchEvent(new CustomEvent('caleta-filter-changed', { detail: { source: currentFilter } }));
         const wrapper = document.getElementById("action-toolbar-wrapper");
         if (wrapper) {
@@ -145,7 +311,6 @@ export const initActionToolbar = () => {
           initActionToolbar();
         }
       }
-      // Cerrar dropdown si está abierto
       dropdownMenu?.classList.add("hidden");
       dropdownBtn?.setAttribute("aria-expanded", "false");
       dropdownChevron?.classList.remove("rotate-180");
@@ -162,14 +327,70 @@ export const initActionToolbar = () => {
     scrollContainer.addEventListener('scroll', _scrollFadeHandler, { passive: true });
     _scrollFadeHandler();
   }
-}
 
-/** @type {(() => void) | null} */
-let _scrollFadeHandler = null;
-/** @type {((e: Event) => void) | null} */
-let _clickDropdownHandler = null;
+  // ── Refresh Button ──────────────────────────────────────────────────────────
+  const refreshBtn = document.getElementById('refresh-prices-btn');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => {
+      if (_isFetching || _cooldownEndTime !== null) return;
+
+      _isFetching = true;
+      _setButtonState('loading');
+      window.dispatchEvent(new CustomEvent('request-prices-refresh', { detail: { manual: true } }));
+    });
+  }
+
+  // ── Listen for prices-updated ───────────────────────────────────────────────
+  _pricesUpdatedHandler = (e) => {
+    const { isManual = false } = /** @type {CustomEvent} */(e).detail ?? {};
+
+    _lastFetchTimestamp = Math.floor(Date.now() / 1000);
+    _isFetching = false;
+
+    if (isManual) {
+      // Escalar cooldown
+      const cooldownDuration = COOLDOWNS[_cooldownLevel] ?? 600;
+      _cooldownLevel = Math.min(_cooldownLevel + 1, COOLDOWNS.length - 1);
+      _cooldownEndTime = _lastFetchTimestamp + cooldownDuration;
+      _setButtonState('cooldown', cooldownDuration);
+    } else {
+      // Refresh automático/inicial — no penaliza cooldown
+      _setButtonState('idle');
+    }
+
+    // Actualizar indicador inmediatamente
+    _updateTimestampDisplay();
+  };
+  window.addEventListener('prices-updated', _pricesUpdatedHandler);
+
+  // ── Listen for prices-update-failed ────────────────────────────────────────
+  _pricesFailedHandler = (e) => {
+    const { isManual = false } = /** @type {CustomEvent} */(e).detail ?? {};
+    _isFetching = false;
+
+    if (isManual) {
+      _setButtonState('error');
+      // Volver a idle tras 1.5s — no penaliza cooldown
+      setTimeout(() => {
+        if (!_isFetching && _cooldownEndTime === null) {
+          _setButtonState('idle');
+        }
+      }, 1500);
+    } else {
+      _setButtonState('idle');
+    }
+  };
+  window.addEventListener('prices-update-failed', _pricesFailedHandler);
+
+  // Arrancar tick interval para el indicador de tiempo
+  _startTickInterval();
+};
+
+// ─── Cleanup ──────────────────────────────────────────────────────────────────
 
 export const cleanupActionToolbar = () => {
+  _stopTickInterval();
+
   if (_scrollFadeHandler) {
     const scrollContainer = document.querySelector('#action-toolbar-wrapper .scroll-fade-container');
     if (scrollContainer) scrollContainer.removeEventListener('scroll', _scrollFadeHandler);
@@ -178,6 +399,14 @@ export const cleanupActionToolbar = () => {
   if (_clickDropdownHandler) {
     document.removeEventListener("click", _clickDropdownHandler);
     _clickDropdownHandler = null;
+  }
+  if (_pricesUpdatedHandler) {
+    window.removeEventListener('prices-updated', _pricesUpdatedHandler);
+    _pricesUpdatedHandler = null;
+  }
+  if (_pricesFailedHandler) {
+    window.removeEventListener('prices-update-failed', _pricesFailedHandler);
+    _pricesFailedHandler = null;
   }
 };
 

--- a/src/components/ActionToolbar.js
+++ b/src/components/ActionToolbar.js
@@ -17,6 +17,8 @@ let _cooldownLevel = 0;
 let _cooldownEndTime = null;
 /** @type {number} Unix timestamp (segundos) del último fetch exitoso. */
 let _lastFetchTimestamp = 0;
+/** @type {number} Unix timestamp (segundos) de referencia para el cálculo de decay de cooldown. */
+let _decayReferenceTimestamp = 0;
 /** @type {ReturnType<typeof setInterval> | null} ID del intervalo de tick. */
 let _tickInterval = null;
 /** @type {boolean} Guard para evitar peticiones concurrentes. */
@@ -220,14 +222,14 @@ const _updateTimestampDisplay = () => {
   // Ej: tras el primer refresh manual, el nivel sube de 0 → 1, por lo que el
   // umbral de decay es COOLDOWNS[1]*2 = 240s en lugar de COOLDOWNS[0]*2 = 120s.
   // Decrementamos el nivel de cooldown de forma progresiva según la inactividad acumulada.
-  if (_cooldownLevel > 0 && _lastFetchTimestamp > 0) {
-    let inactiveFor = now - _lastFetchTimestamp;
+  if (_cooldownLevel > 0 && _decayReferenceTimestamp > 0) {
+    let inactiveFor = now - _decayReferenceTimestamp;
     while (_cooldownLevel > 0) {
       const currentCooldown = COOLDOWNS[_cooldownLevel] ?? 600;
       const threshold = currentCooldown * 2;
       if (inactiveFor > threshold) {
         _cooldownLevel--;
-        _lastFetchTimestamp += threshold;
+        _decayReferenceTimestamp += threshold;
         inactiveFor -= threshold;
       } else {
         break;
@@ -262,7 +264,7 @@ let _pricesFailedHandler = null;
 // ─── Init ─────────────────────────────────────────────────────────────────────
 
 export const initActionToolbar = () => {
-  cleanupActionToolbar();
+  cleanupActionToolbar(true);
 
   // Add Wallet
   const addWalletBtn = document.getElementById("add-wallet");
@@ -361,6 +363,7 @@ export const initActionToolbar = () => {
     if (fetchFailed) return;
 
     _lastFetchTimestamp = Math.floor(Date.now() / 1000);
+    _decayReferenceTimestamp = _lastFetchTimestamp;
     _isFetching = false;
 
     if (isManual) {
@@ -400,21 +403,41 @@ export const initActionToolbar = () => {
 
   // Arrancar tick interval para el indicador de tiempo
   _startTickInterval();
+
+  // Restablecer el estado visual del botón de refresco y el indicador inmediatamente
+  if (_isFetching) {
+    _setButtonState('loading');
+  } else if (_cooldownEndTime !== null) {
+    const now = Math.floor(Date.now() / 1000);
+    const remaining = _cooldownEndTime - now;
+    if (remaining > 0) {
+      _setButtonState('cooldown', remaining);
+    } else {
+      _cooldownEndTime = null;
+      _setButtonState('idle');
+    }
+  } else {
+    _setButtonState('idle');
+  }
+  _updateTimestampDisplay();
 };
 
 // ─── Cleanup ──────────────────────────────────────────────────────────────────
 
-export const cleanupActionToolbar = () => {
+export const cleanupActionToolbar = (keepState = false) => {
   _stopTickInterval();
 
   // Resetear estado volátil para evitar que persista entre navegaciones SPA.
   // _isFetching es el más crítico: si un fetch manual estaba en vuelo cuando el
   // usuario navegó (y HoldingsTable también fue limpiado), el evento 'prices-updated'
   // nunca llegaría y el botón quedaría bloqueado hasta el próximo fetch automático.
-  _isFetching = false;
-  _cooldownEndTime = null;
-  _lastFetchTimestamp = 0;
-  _cooldownLevel = 0;
+  if (!keepState) {
+    _isFetching = false;
+    _cooldownEndTime = null;
+    _lastFetchTimestamp = 0;
+    _decayReferenceTimestamp = 0;
+    _cooldownLevel = 0;
+  }
 
   if (_scrollFadeHandler) {
     const scrollContainer = document.querySelector('#action-toolbar-wrapper .scroll-fade-container');

--- a/src/components/ActionToolbar.js
+++ b/src/components/ActionToolbar.js
@@ -214,16 +214,24 @@ const _updateTimestampDisplay = () => {
     }
   }
 
-  // 3. Decremento de nivel de Cooldown por inactividad prolongada.
+  // 3. Decremento progresivo del nivel de Cooldown por inactividad prolongada.
   // Nota: se usa COOLDOWNS[_cooldownLevel] (nivel ya incrementado) como umbral,
   // lo que hace el decay más lento de forma intencional (anti-abuse progresivo).
   // Ej: tras el primer refresh manual, el nivel sube de 0 → 1, por lo que el
   // umbral de decay es COOLDOWNS[1]*2 = 240s en lugar de COOLDOWNS[0]*2 = 120s.
+  // Decrementamos el nivel de cooldown de forma progresiva según la inactividad acumulada.
   if (_cooldownLevel > 0 && _lastFetchTimestamp > 0) {
-    const inactiveFor = now - _lastFetchTimestamp;
-    const currentCooldown = COOLDOWNS[_cooldownLevel] ?? 600;
-    if (inactiveFor > currentCooldown * 2) {
-      _cooldownLevel = 0;
+    let inactiveFor = now - _lastFetchTimestamp;
+    while (_cooldownLevel > 0) {
+      const currentCooldown = COOLDOWNS[_cooldownLevel] ?? 600;
+      const threshold = currentCooldown * 2;
+      if (inactiveFor > threshold) {
+        _cooldownLevel--;
+        _lastFetchTimestamp += threshold;
+        inactiveFor -= threshold;
+      } else {
+        break;
+      }
     }
   }
 };
@@ -346,7 +354,11 @@ export const initActionToolbar = () => {
 
   // ── Listen for prices-updated ───────────────────────────────────────────────
   _pricesUpdatedHandler = (e) => {
-    const { isManual = false } = /** @type {CustomEvent} */(e).detail ?? {};
+    const { isManual = false, fetchFailed = false } = /** @type {CustomEvent} */(e).detail ?? {};
+
+    // Si el fetch falló, 'prices-update-failed' ya manejó el estado del botón.
+    // Solo actualizamos el cooldown y el timestamp en el path exitoso.
+    if (fetchFailed) return;
 
     _lastFetchTimestamp = Math.floor(Date.now() / 1000);
     _isFetching = false;

--- a/src/components/ActionToolbar.js
+++ b/src/components/ActionToolbar.js
@@ -214,7 +214,11 @@ const _updateTimestampDisplay = () => {
     }
   }
 
-  // 3. Decremento de nivel de Cooldown por inactividad prolongada
+  // 3. Decremento de nivel de Cooldown por inactividad prolongada.
+  // Nota: se usa COOLDOWNS[_cooldownLevel] (nivel ya incrementado) como umbral,
+  // lo que hace el decay más lento de forma intencional (anti-abuse progresivo).
+  // Ej: tras el primer refresh manual, el nivel sube de 0 → 1, por lo que el
+  // umbral de decay es COOLDOWNS[1]*2 = 240s en lugar de COOLDOWNS[0]*2 = 120s.
   if (_cooldownLevel > 0 && _lastFetchTimestamp > 0) {
     const inactiveFor = now - _lastFetchTimestamp;
     const currentCooldown = COOLDOWNS[_cooldownLevel] ?? 600;
@@ -390,6 +394,15 @@ export const initActionToolbar = () => {
 
 export const cleanupActionToolbar = () => {
   _stopTickInterval();
+
+  // Resetear estado volátil para evitar que persista entre navegaciones SPA.
+  // _isFetching es el más crítico: si un fetch manual estaba en vuelo cuando el
+  // usuario navegó (y HoldingsTable también fue limpiado), el evento 'prices-updated'
+  // nunca llegaría y el botón quedaría bloqueado hasta el próximo fetch automático.
+  _isFetching = false;
+  _cooldownEndTime = null;
+  _lastFetchTimestamp = 0;
+  _cooldownLevel = 0;
 
   if (_scrollFadeHandler) {
     const scrollContainer = document.querySelector('#action-toolbar-wrapper .scroll-fade-container');

--- a/src/components/HoldingsTable.js
+++ b/src/components/HoldingsTable.js
@@ -132,15 +132,6 @@ const HoldingsTable = () => {
               <use href="${sprite}#filter-2" />
             </svg>
           </button>
-          <button
-            id="refresh-prices-btn"
-            class="text-slate-400 transition-colors hover:text-white group"
-            aria-label="Refresh prices"
-          >
-            <svg class="w-5 h-5 transition-transform group-active:rotate-180 duration-500" aria-hidden="true">
-              <use href="${sprite}#refresh" />
-            </svg>
-          </button>
         </div>
       </div>
 
@@ -187,8 +178,8 @@ const HoldingsTable = () => {
 let _filterHandler = null;
 /** @type {((e: Event) => void) | null} */
 let _holdingsHandler = null;
-/** @type {(() => void) | null} */
-let _refreshHandler = null;
+/** @type {((e: Event) => void) | null} */
+let _refreshRequestedHandler = null;
 /** @type {(() => void) | null} */
 let _scrollFadeHandler = null;
 
@@ -278,7 +269,11 @@ export const initHoldingsTable = () => {
     _scrollFadeHandler(); // initial check
   };
 
-  const fetchPricesAndUpdate = async () => {
+  /**
+   * Obtiene precios actualizados del API y refresca la tabla.
+   * @param {boolean} [isManual=false] - Si el refresco fue iniciado manualmente por el usuario.
+   */
+  const fetchPricesAndUpdate = async (isManual = false) => {
     const rawHoldings = getHoldings();
     const filteredHoldings = activeFilter === 'Caletas'
       ? rawHoldings
@@ -289,8 +284,10 @@ export const initHoldingsTable = () => {
     if (data.length === 0) {
       currentData = [];
       updateDisplay(1);
-      // Still notify StatsGrid so it shows zeros
-      window.dispatchEvent(new CustomEvent('prices-updated', { detail: { holdings: [], usingCachedPrices: false } }));
+      // Notificar a StatsGrid y a ActionToolbar (con isManual)
+      window.dispatchEvent(new CustomEvent('prices-updated', {
+        detail: { holdings: [], usingCachedPrices: false, isManual }
+      }));
       return;
     }
 
@@ -342,13 +339,18 @@ export const initHoldingsTable = () => {
         showWarning(userMsg, 7000);
         console.warn('HoldingsTable: precio en caché —', err.message);
       }
+
+      // Notificar a ActionToolbar del fallo
+      window.dispatchEvent(new CustomEvent('prices-update-failed', {
+        detail: { isManual }
+      }));
     }
 
     currentData = data;
 
-    // Dispatch event for StatsGrid — include cached flag
+    // Dispatch event para StatsGrid y ActionToolbar — incluye flags de caché y manual
     window.dispatchEvent(new CustomEvent('prices-updated', {
-      detail: { holdings: currentData, usingCachedPrices }
+      detail: { holdings: currentData, usingCachedPrices, isManual }
     }));
 
     updateDisplay(Number(table.dataset.currentPage) || 1);
@@ -357,25 +359,19 @@ export const initHoldingsTable = () => {
     _updateCachedBadge(usingCachedPrices);
   };
 
-  // Initial Load
-  fetchPricesAndUpdate();
+  // Initial Load (no es manual — no penaliza cooldown)
+  fetchPricesAndUpdate(false);
 
-  // Manual Refresh Button
-  const refreshBtn = document.getElementById("refresh-prices-btn");
-  if (refreshBtn) {
-    _refreshHandler = () => {
-      const btn = document.getElementById("refresh-prices-btn");
-      btn?.querySelector('svg')?.classList.add("animate-spin");
-      fetchPricesAndUpdate().finally(() => {
-        setTimeout(() => btn?.querySelector('svg')?.classList.remove("animate-spin"), 500);
-      });
-    };
-    refreshBtn.addEventListener("click", _refreshHandler);
-  }
+  // Escuchar petición de refresco desde ActionToolbar
+  _refreshRequestedHandler = (e) => {
+    const isManual = /** @type {CustomEvent} */(e).detail?.manual ?? false;
+    fetchPricesAndUpdate(isManual);
+  };
+  window.addEventListener('request-prices-refresh', _refreshRequestedHandler);
 
   // Listen for new transactions
   _holdingsHandler = () => {
-    fetchPricesAndUpdate();
+    fetchPricesAndUpdate(false);
   };
   window.addEventListener('holdings-updated', _holdingsHandler);
 };
@@ -436,10 +432,9 @@ export const cleanupHoldingsTable = () => {
     window.removeEventListener('holdings-updated', _holdingsHandler);
     _holdingsHandler = null;
   }
-  if (_refreshHandler) {
-    const btn = document.getElementById("refresh-prices-btn");
-    if (btn) btn.removeEventListener("click", _refreshHandler);
-    _refreshHandler = null;
+  if (_refreshRequestedHandler) {
+    window.removeEventListener('request-prices-refresh', _refreshRequestedHandler);
+    _refreshRequestedHandler = null;
   }
   if (_scrollFadeHandler) {
     const wrapper = document.getElementById("holdings-scroll-wrapper");

--- a/src/components/HoldingsTable.js
+++ b/src/components/HoldingsTable.js
@@ -295,6 +295,8 @@ export const initHoldingsTable = () => {
 
     /** @type {boolean} */
     let usingCachedPrices = false;
+    /** @type {boolean} Bandera que previene emitir 'prices-updated' si el fetch falló. */
+    let fetchFailed = false;
 
     try {
       const url = `${process.env.API_URL}/coins/markets?vs_currency=usd&ids=${coinIds}&sparkline=true`;
@@ -327,6 +329,7 @@ export const initHoldingsTable = () => {
         throw new ApiError(ErrorType.PARSE, "La respuesta de la API no es un listado válido.");
       }
     } catch (err) {
+      fetchFailed = true;
       usingCachedPrices = true;
 
       // Fallback: calculate value using the last known price
@@ -340,23 +343,26 @@ export const initHoldingsTable = () => {
         console.warn('HoldingsTable: precio en caché —', err.message);
       }
 
-      // Notificar a ActionToolbar del fallo
+      // Notificar a ActionToolbar del fallo — no escala cooldown ni bloquea el botón
       window.dispatchEvent(new CustomEvent('prices-update-failed', {
         detail: { isManual }
       }));
     }
 
+    // Actualizar estado interno y UI en ambos paths (éxito y fallback con caché)
     currentData = data;
-
-    // Dispatch event para StatsGrid y ActionToolbar — incluye flags de caché y manual
-    window.dispatchEvent(new CustomEvent('prices-updated', {
-      detail: { holdings: currentData, usingCachedPrices, isManual }
-    }));
-
     updateDisplay(Number(table.dataset.currentPage) || 1);
 
     // Mostrar/ocultar badge de precios cacheados en el header de la tabla
     _updateCachedBadge(usingCachedPrices);
+
+    // Solo emitir 'prices-updated' si el fetch fue exitoso.
+    // Evita sobreescribir el estado 'error' del botón y penalizar el cooldown en caso de fallo.
+    if (!fetchFailed) {
+      window.dispatchEvent(new CustomEvent('prices-updated', {
+        detail: { holdings: currentData, usingCachedPrices, isManual }
+      }));
+    }
   };
 
   // Initial Load (no es manual — no penaliza cooldown)

--- a/src/components/HoldingsTable.js
+++ b/src/components/HoldingsTable.js
@@ -174,6 +174,9 @@ const HoldingsTable = () => {
   return view;
 };
 
+/** @type {AbortController | null} */
+let _priceFetchAbortController = null;
+
 /** @type {((e: Event) => void) | null} */
 let _filterHandler = null;
 /** @type {((e: Event) => void) | null} */
@@ -274,6 +277,13 @@ export const initHoldingsTable = () => {
    * @param {boolean} [isManual=false] - Si el refresco fue iniciado manualmente por el usuario.
    */
   const fetchPricesAndUpdate = async (isManual = false) => {
+    // Si ya hay una petición en curso, cancelarla para evitar condiciones de carrera (concurrency guard)
+    if (_priceFetchAbortController) {
+      _priceFetchAbortController.abort();
+    }
+    _priceFetchAbortController = new AbortController();
+    const signal = _priceFetchAbortController.signal;
+
     const rawHoldings = getHoldings();
     const filteredHoldings = activeFilter === 'Caletas'
       ? rawHoldings
@@ -282,6 +292,7 @@ export const initHoldingsTable = () => {
     let data = aggregateHoldings(filteredHoldings, activeFilter);
 
     if (data.length === 0) {
+      _priceFetchAbortController = null;
       currentData = [];
       updateDisplay(1);
       // Notificar a StatsGrid y a ActionToolbar (con isManual)
@@ -295,12 +306,15 @@ export const initHoldingsTable = () => {
 
     /** @type {boolean} */
     let usingCachedPrices = false;
-    /** @type {boolean} Bandera que previene emitir 'prices-updated' si el fetch falló. */
+    /** @type {boolean} Indica si el fetch falló — se propaga en el detail del evento
+     *  para que ActionToolbar evite escalar el cooldown sin suprimir el evento para
+     *  StatsGrid y AllocationDonut. */
     let fetchFailed = false;
 
     try {
       const url = `${process.env.API_URL}/coins/markets?vs_currency=usd&ids=${coinIds}&sparkline=true`;
       const fetchOptions = {
+        signal,
         headers: {
           'Content-Type': 'application/json',
           'x-cg-demo-api-key': process.env.API_KEY || ''
@@ -319,23 +333,26 @@ export const initHoldingsTable = () => {
               change24h: market.price_change_percentage_24h,
               value: asset.balance * market.current_price,
               sparkColor: market.price_change_percentage_24h >= 0 ? "#0bd570" : "#ef4444",
-              // In a more advanced version, we would parse market.sparkline_in_7d.price to SVG path
             };
           }
-          // Recalculate value with stored price if API fails for this specific coin
           return { ...asset, value: asset.balance * asset.price };
         });
       } else {
         throw new ApiError(ErrorType.PARSE, "La respuesta de la API no es un listado válido.");
       }
     } catch (err) {
+      // Si fue cancelada intencionalmente por un fetch más nuevo, salir silenciosamente
+      if (err instanceof ApiError && err.type === ErrorType.ABORT) {
+        return;
+      }
+
       fetchFailed = true;
       usingCachedPrices = true;
 
       // Fallback: calculate value using the last known price
       data = data.map(a => ({ ...a, value: a.balance * a.price }));
 
-      if (err instanceof ApiError && err.type !== ErrorType.ABORT) {
+      if (err instanceof ApiError) {
         const userMsg = err.type === ErrorType.RATE_LIMIT
           ? 'Límite de peticiones alcanzado. Mostrando precios del último guardado.'
           : `${getErrorMessage(err.type)} Mostrando precios del último guardado.`;
@@ -347,6 +364,11 @@ export const initHoldingsTable = () => {
       window.dispatchEvent(new CustomEvent('prices-update-failed', {
         detail: { isManual }
       }));
+    } finally {
+      // Limpiar el abort controller si este fetch sigue siendo el actual
+      if (_priceFetchAbortController?.signal === signal) {
+        _priceFetchAbortController = null;
+      }
     }
 
     // Actualizar estado interno y UI en ambos paths (éxito y fallback con caché)
@@ -356,13 +378,12 @@ export const initHoldingsTable = () => {
     // Mostrar/ocultar badge de precios cacheados en el header de la tabla
     _updateCachedBadge(usingCachedPrices);
 
-    // Solo emitir 'prices-updated' si el fetch fue exitoso.
-    // Evita sobreescribir el estado 'error' del botón y penalizar el cooldown en caso de fallo.
-    if (!fetchFailed) {
-      window.dispatchEvent(new CustomEvent('prices-updated', {
-        detail: { holdings: currentData, usingCachedPrices, isManual }
-      }));
-    }
+    // Siempre despachar 'prices-updated' — StatsGrid y AllocationDonut dependen de este evento
+    // para renderizar incluso cuando los datos vienen de caché. Se incluye `fetchFailed` en el
+    // detail para que ActionToolbar no escale el cooldown si el fetch falló.
+    window.dispatchEvent(new CustomEvent('prices-updated', {
+      detail: { holdings: currentData, usingCachedPrices, isManual, fetchFailed }
+    }));
   };
 
   // Initial Load (no es manual — no penaliza cooldown)
@@ -446,6 +467,10 @@ export const cleanupHoldingsTable = () => {
     const wrapper = document.getElementById("holdings-scroll-wrapper");
     if (wrapper) wrapper.removeEventListener("scroll", _scrollFadeHandler);
     _scrollFadeHandler = null;
+  }
+  if (_priceFetchAbortController) {
+    _priceFetchAbortController.abort();
+    _priceFetchAbortController = null;
   }
 };
 

--- a/src/components/HoldingsTable.js
+++ b/src/components/HoldingsTable.js
@@ -295,9 +295,9 @@ export const initHoldingsTable = () => {
       _priceFetchAbortController = null;
       currentData = [];
       updateDisplay(1);
-      // Notificar a StatsGrid y a ActionToolbar (con isManual)
+      // Notificar a StatsGrid y a ActionToolbar (forzamos isManual a false porque no se consumió cuota de la API)
       window.dispatchEvent(new CustomEvent('prices-updated', {
-        detail: { holdings: [], usingCachedPrices: false, isManual }
+        detail: { holdings: [], usingCachedPrices: false, isManual: false }
       }));
       return;
     }

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -48,10 +48,15 @@ const router = async () => {
     header.innerHTML = Header(path);
     root.innerHTML = await render(params);
 
-    // Wire up interactive components after the DOM is populated
-    // Order matters: listeners (StatsGrid, AllocationDonut) must register BEFORE
-    // HoldingsTable dispatches 'prices-updated', which can happen synchronously
-    // when aggregated holdings have zero net balance.
+    // Wire up interactive components after the DOM is populated.
+    // ⚠️  ORDER IS CRITICAL — listeners must register BEFORE HoldingsTable dispatches events:
+    //   - ActionToolbar : registers 'prices-updated' / 'prices-update-failed' handlers
+    //                     (controls button state + cooldown + timestamp indicator)
+    //   - StatsGrid     : registers 'prices-updated' handler (updates portfolio totals)
+    //   - AllocationDonut: registers 'prices-updated' handler (updates donut chart)
+    //   - HoldingsTable : dispatches 'prices-updated' / 'prices-update-failed' on first load,
+    //                     which may happen synchronously when net balance is zero.
+    // Reordering init calls below will silently break the cooldown state machine or stats display.
     if (path === "/") {
       initActionToolbar();
       initStatsGrid();       // Registers prices-updated listener

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -25,16 +25,16 @@ export const formatBalance = (n) =>
 export const formatPercent = (n) => `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`;
 
 /**
- * Formatea segundos transcurridos a un string relativo amigable en español.
- * Utiliza `Intl.RelativeTimeFormat` para internacionalización nativa.
+ * Formats elapsed seconds into a human-friendly relative time string (English).
+ * Uses native `Intl.RelativeTimeFormat` for i18n-safe output.
  *
- * @param {number} elapsedSeconds - Segundos transcurridos desde el último evento.
- * @returns {string} Texto relativo (ej. "ahora mismo", "hace 2 minutos").
+ * @param {number} elapsedSeconds - Seconds elapsed since the last event.
+ * @returns {string} Relative string (e.g. "just now", "2 minutes ago").
  */
 export const formatRelativeTime = (elapsedSeconds) => {
-  const rtf = new Intl.RelativeTimeFormat('es', { numeric: 'auto', style: 'long' });
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto', style: 'long' });
 
-  if (elapsedSeconds < 5) return 'ahora mismo';
+  if (elapsedSeconds < 5) return 'just now';
   if (elapsedSeconds < 60) return rtf.format(-Math.floor(elapsedSeconds), 'second');
 
   const minutes = Math.floor(elapsedSeconds / 60);

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -25,6 +25,29 @@ export const formatBalance = (n) =>
 export const formatPercent = (n) => `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`;
 
 /**
+ * Formatea segundos transcurridos a un string relativo amigable en español.
+ * Utiliza `Intl.RelativeTimeFormat` para internacionalización nativa.
+ *
+ * @param {number} elapsedSeconds - Segundos transcurridos desde el último evento.
+ * @returns {string} Texto relativo (ej. "ahora mismo", "hace 2 minutos").
+ */
+export const formatRelativeTime = (elapsedSeconds) => {
+  const rtf = new Intl.RelativeTimeFormat('es', { numeric: 'auto', style: 'long' });
+
+  if (elapsedSeconds < 5) return 'ahora mismo';
+  if (elapsedSeconds < 60) return rtf.format(-Math.floor(elapsedSeconds), 'second');
+
+  const minutes = Math.floor(elapsedSeconds / 60);
+  if (minutes < 60) return rtf.format(-minutes, 'minute');
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return rtf.format(-hours, 'hour');
+
+  const days = Math.floor(hours / 24);
+  return rtf.format(-days, 'day');
+};
+
+/**
  * Returns the current local date and time formatted for an HTML <input type="datetime-local">.
  * Format: YYYY-MM-DDThh:mm
  *


### PR DESCRIPTION
🎯 Objetivo
Añadir un indicador visual del tiempo transcurrido desde la última actualización de precios y un botón de refresco manual con cooldown progresivo en la ActionToolbar, protegiendo el rate-limit de la API de CoinGecko y mejorando la experiencia global de la aplicación.

📋 Contexto
Antes de este cambio, el botón de refresco estaba anidado dentro de HoldingsTable — acoplando directamente la UI de refresh con la lógica de datos. Esto hacía imposible coordinar el estado del botón con el indicador de tiempo y el cooldown desde un punto central.

🔄 Flujo de Eventos (desacoplado)
Click #refresh-prices-btn (ActionToolbar)
  └─→ window: 'request-prices-refresh' { manual: true }
        └─→ HoldingsTable: fetchPricesAndUpdate(isManual)
              ├─ Éxito → window: 'prices-updated' { holdings, usingCachedPrices, isManual }
              │              └─→ ActionToolbar: escala cooldown si isManual, actualiza timestamp
              └─ Error  → window: 'prices-update-failed' { isManual }
                             └─→ ActionToolbar: estado 'error' 1.5s, sin penalizar cooldown
📁 Archivos Modificados
src/utils/formatters.js (+23)
Nueva función pura formatRelativeTime(elapsedSeconds) usando Intl.RelativeTimeFormat('es').
Cubre rangos: segundos → minutos → horas → días.
Retorna 'ahora mismo' para valores < 5s.
src/components/ActionToolbar.js (+242 / -13)
Nuevo botón #refresh-prices-btn movido al grupo derecho de la toolbar, junto al indicador de tiempo #last-update-indicator.
Máquina de estados del botón: idle → loading → cooldown → error con transiciones explícitas.
Cooldown progresivo de 4 niveles: 60s → 120s → 300s → 600s. Se escala con cada refresh manual exitoso y se resetea por inactividad.
Tick interval (setInterval 1s) que actualiza el indicador de tiempo y gestiona el fin de cooldown.
Escucha eventos prices-updated y prices-update-failed del window.
Cleanup completo en cleanupActionToolbar().
src/components/HoldingsTable.js (+31 / -36)
Eliminado el botón de refresh local del header de la tabla.
fetchPricesAndUpdate ahora acepta isManual: boolean (default false).
Emite prices-updated con { holdings, usingCachedPrices, isManual } en éxito.
Emite prices-update-failed con { isManual } en caso de error/excepción.
Escucha request-prices-refresh para ejecutar el fetch desde ActionToolbar.
Carga inicial y actualizaciones por nuevas transacciones pasan isManual: false → no penalizan cooldown.
🎛️ Estados Visuales del Botón
Estado	Apariencia	disabled	aria-label
Idle	🔄 Refresh	false	Refresh prices
Loading	⏳ Updating... (spin)	true	Refreshing prices, please wait
Cooldown	⌛ Wait Xs	true	Refresh available in X seconds
Error	⚠️ Failed (borde rojo)	false	Refresh failed. Click to retry
♿ Accesibilidad
#last-update-indicator tiene aria-live="polite" y aria-atomic="true" — los lectores de pantalla anuncian actualizaciones de forma no intrusiva.
El botón actualiza su aria-label dinámicamente según el estado activo.
En estados loading / cooldown, el botón queda disabled para prevenir interacción por teclado y mouse.
El indicador de tiempo está oculto en móvil (hidden sm:inline) para evitar saturación visual.
✅ Testing Manual Recomendado
Cargar la app → el indicador debe mostrar Updated ahora mismo y actualizarse cada segundo.
Click en Refresh → botón pasa a loading, luego a cooldown (60s la primera vez).
Intentar hacer click durante el cooldown → el botón no responde.
Esperar a que expire el cooldown → el botón vuelve a idle.
Hacer click nuevamente → cooldown sube a 120s.
Simular error de red (DevTools → Offline) → botón muestra estado error 1.5s, luego idle sin penalizar cooldown.